### PR TITLE
ci: add firebase preview channel on PRs

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,21 @@
+name: pull-request
+on: pull_request
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build & Export
+        run: npm run export:staging
+      - uses: FirebaseExtended/action-hosting-deploy@v0.3-alpha
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_CHANNEL_DEPLOY_SERVICE_ACCOUNT }}"
+          projectId: staging
+          expires: 14d
+        env:
+          FIREBASE_CLI_PREVIEWS: hostingchannels


### PR DESCRIPTION
Adds a new Firebase feature of auto-deploying to temporary preview channels! When opening a new PR, the action should create a unique and temporary link to preview the changes with and post that as a comment. Hopefully it will help with reviewing new additions!

https://firebase.googleblog.com/2020/10/preview-channels-firebase-hosting.html

Note: I've used it before and have encountered an issue/bug that depends on branch naming. It makes the temporary link based on the branch name and if it _ends_ with an hyphen, underscore, or hash sign (including after the branch name gets truncated if it's too long) then the action will fail. In such case, a hacky workaround is branching off with a valid name and opening another PR :stuck_out_tongue: 