### PR TITLE
feat: close applications

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -2,12 +2,11 @@ import { ReactElement } from "react";
 import { BodyAuto, Headline3, Link } from "@/components/core/Text";
 import { CTAButton } from "@/components/core/Button";
 import { styles } from "@/src/constants";
-import { Box, Flex, Icon } from "@chakra-ui/core";
+import { Box, Flex } from "@chakra-ui/core";
 import Decoration from "@/components/Decoration";
 import Wrapper from "@/components/Wrapper";
 import Lottie from "react-lottie";
 import animationData from "@/src/hero-lottie.json";
-import NextLink from "next/link";
 
 const headlineFontSizes = [48, 48, 48, 58, 72];
 const headlineLineHeights = [0.9, 0.9, 1];
@@ -20,12 +19,6 @@ const lottieOptions = {
     preserveAspectRatio: "xMidYMid slice",
   },
 };
-
-const ApplyIcon = () => (
-  <Flex size="14px" align="center" marginLeft="8px" overflow="visible">
-    <Icon name="arrow-forward" size="24px" />
-  </Flex>
-);
 
 function Hero(): ReactElement {
   return (
@@ -56,20 +49,13 @@ function Hero(): ReactElement {
                 <BodyAuto paddingTop={4}>
                   MLH Member Event · Hosted Virtually Worldwide
                 </BodyAuto>
-                <BodyAuto paddingTop={4}>
-                  Applications extended until February 3rd
-                </BodyAuto>
                 <Flex
                   w="max-content"
                   marginTop={[12, 12, 16]}
                   flexDirection={["column", "column", "row", "row"]}
                   alignItems={["flex-start", "flex-start", "center"]}
                 >
-                  <NextLink href="/apply" passHref>
-                    <Link>
-                      <CTAButton rightIcon={ApplyIcon}>Apply Now</CTAButton>
-                    </Link>
-                  </NextLink>
+                  <CTAButton>Applications Closed</CTAButton>
                   <Link
                     href="mailto:sponsorship@uottahack.ca"
                     marginLeft={[0, 0, 8]}


### PR DESCRIPTION
This PR only updates the content of the main page to say that applications are closed.

Meanwhile the TypeForm collecting responses is scheduled to close at midnight (EST), so right when Feb 4th starts. Instead of the usual application form, it will have a message saying that it's closed.

![image](https://user-images.githubusercontent.com/20251243/106821020-67cc7e00-664a-11eb-938d-f95a6284ecb6.png)

I'm not sure if this is the right call, but I kept the `/apply` path in `firebase.json` in case some visitors are on an old cached version that still has the apply button, so that it shows the above TypeForm screen instead of doing nothing when clicked. This also won't break links that goes directly to https://2021.uottahack.ca/apply
